### PR TITLE
feat: Added (m *MonochromeExposure) Preprocess() to the IRIS monochrome module. 

### DIFF
--- a/coverage.txt
+++ b/coverage.txt
@@ -1,5 +1,4 @@
 mode: atomic
-github.com/observerly/iris/pkg/iris/monochrome.go:16.84,28.2 3 2
 github.com/observerly/iris/pkg/fits/fits.go:17.33,28.2 1 2
 github.com/observerly/iris/pkg/fits/fits.go:47.32,52.2 1 1
 github.com/observerly/iris/pkg/fits/fits.go:56.72,59.31 2 1
@@ -8,3 +7,11 @@ github.com/observerly/iris/pkg/fits/fits.go:67.2,78.3 1 1
 github.com/observerly/iris/pkg/fits/fits.go:59.31,61.3 1 2
 github.com/observerly/iris/pkg/fits/fits.go:63.17,65.3 1 1
 github.com/observerly/iris/pkg/fits/fits.go:83.55,98.2 2 1
+github.com/observerly/iris/pkg/iris/monochrome.go:19.84,31.2 3 4
+github.com/observerly/iris/pkg/iris/monochrome.go:33.65,38.31 3 2
+github.com/observerly/iris/pkg/iris/monochrome.go:47.2,53.16 4 2
+github.com/observerly/iris/pkg/iris/monochrome.go:57.2,57.18 1 2
+github.com/observerly/iris/pkg/iris/monochrome.go:38.31,39.33 1 20
+github.com/observerly/iris/pkg/iris/monochrome.go:39.33,40.22 1 272
+github.com/observerly/iris/pkg/iris/monochrome.go:40.22,43.5 2 272
+github.com/observerly/iris/pkg/iris/monochrome.go:53.16,55.3 1 0

--- a/pkg/iris/monochrome_test.go
+++ b/pkg/iris/monochrome_test.go
@@ -1,6 +1,10 @@
 package iris
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"testing"
+)
 
 var ex = [][]uint32{}
 
@@ -25,5 +29,127 @@ func TestNewMonochromeExposureHeight(t *testing.T) {
 
 	if got != want {
 		t.Errorf("got %q, wanted %q", got, want)
+	}
+}
+
+func TestNewMonochromeExposurePreprocess4x4(t *testing.T) {
+	var ex = [][]uint32{
+		{6, 6, 6, 6},
+		{6, 7, 8, 8},
+		{7, 8, 9, 7},
+		{6, 7, 8, 6},
+	}
+
+	mono := NewMonochromeExposure(ex, 4, 4)
+
+	var x int = mono.Width
+
+	var y int = mono.Height
+
+	if x != 4 {
+		t.Errorf("got %q, wanted %q", x, 4)
+	}
+
+	if y != 4 {
+		t.Errorf("got %q, wanted %q", y, 4)
+	}
+
+	buff, err := mono.Preprocess()
+
+	if err != nil {
+		t.Errorf("Expected the buffer to be created successfully, but got %q", err)
+	}
+
+	f, err := os.Create("4x4image.jpg")
+
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("Expected the image buffer to be saved successfully, but got %q", err)
+		}
+
+		// Clean up the file after we have finished with the test:
+		os.Remove("4x4image.jpg")
+	}()
+
+	n, err := f.Write(buff.Bytes())
+
+	if err != nil {
+		t.Errorf("Expected the image buffer to be saved successfully, but got %q", err)
+	}
+
+	fmt.Println(n)
+
+	if n >= 512 {
+		t.Errorf("Expected the number of bytes to be approximately less than 128, but got %v", n)
+	}
+}
+
+func TestNewMonochromeExposurePreprocess16x16(t *testing.T) {
+	var ex = [][]uint32{
+		{6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6},
+		{6, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 7, 6},
+		{7, 8, 9, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 9, 8, 7},
+		{6, 7, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 8, 7, 6},
+		{6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6},
+		{6, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 7, 6},
+		{7, 8, 9, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 9, 8, 7},
+		{6, 7, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 8, 7, 6},
+		{6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6},
+		{6, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 7, 6},
+		{7, 8, 9, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 9, 8, 7},
+		{6, 7, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 8, 7, 6},
+		{6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6},
+		{6, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 7, 6},
+		{7, 8, 9, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 9, 8, 7},
+		{6, 7, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 8, 7, 6},
+	}
+
+	mono := NewMonochromeExposure(ex, 16, 16)
+
+	var x int = mono.Width
+
+	var y int = mono.Height
+
+	if x != 16 {
+		t.Errorf("got %q, wanted %q", x, 16)
+	}
+
+	if y != 16 {
+		t.Errorf("got %q, wanted %q", y, 16)
+	}
+
+	buff, err := mono.Preprocess()
+
+	if err != nil {
+		t.Errorf("Expected the buffer to be created successfully, but got %q", err)
+	}
+
+	f, err := os.Create("16x16image.jpg")
+
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("Expected the image buffer to be saved successfully, but got %q", err)
+		}
+
+		// Clean up the file after we have finished with the test:
+		os.Remove("16x16image.jpg")
+	}()
+
+	n, err := f.Write(buff.Bytes())
+
+	if err != nil {
+		t.Errorf("Expected the image buffer to be saved successfully, but got %q", err)
+	}
+
+	if n >= 1086 {
+		t.Errorf("Expected the number of bytes to be approximately less than 1086, but got %q", n)
 	}
 }


### PR DESCRIPTION
feat: Added (m *MonochromeExposure) Preprocess() to the IRIS monochrome module. 

Includes associated test suite for module export definition and expected output.