### PR TITLE
fix: Removed sync.WaitGroup from (m *MonochromeExposure) Preprocess().

### DIFF
--- a/coverage.txt
+++ b/coverage.txt
@@ -1,12 +1,4 @@
 mode: atomic
-github.com/observerly/iris/pkg/fits/fits.go:17.33,28.2 1 2
-github.com/observerly/iris/pkg/fits/fits.go:47.32,52.2 1 1
-github.com/observerly/iris/pkg/fits/fits.go:56.72,59.31 2 1
-github.com/observerly/iris/pkg/fits/fits.go:63.2,63.17 1 1
-github.com/observerly/iris/pkg/fits/fits.go:67.2,78.3 1 1
-github.com/observerly/iris/pkg/fits/fits.go:59.31,61.3 1 2
-github.com/observerly/iris/pkg/fits/fits.go:63.17,65.3 1 1
-github.com/observerly/iris/pkg/fits/fits.go:83.55,98.2 2 1
 github.com/observerly/iris/pkg/photometry/stars.go:22.93,27.29 2 2
 github.com/observerly/iris/pkg/photometry/stars.go:31.2,40.3 2 2
 github.com/observerly/iris/pkg/photometry/stars.go:27.29,29.3 1 32
@@ -17,6 +9,21 @@ github.com/observerly/iris/pkg/photometry/stars.go:48.35,52.22 2 24
 github.com/observerly/iris/pkg/photometry/stars.go:62.4,62.29 1 24
 github.com/observerly/iris/pkg/photometry/stars.go:52.22,56.85 2 23
 github.com/observerly/iris/pkg/photometry/stars.go:56.85,58.6 1 5
+github.com/observerly/iris/pkg/fits/fits.go:17.33,28.2 1 2
+github.com/observerly/iris/pkg/fits/fits.go:47.32,52.2 1 1
+github.com/observerly/iris/pkg/fits/fits.go:56.72,59.31 2 1
+github.com/observerly/iris/pkg/fits/fits.go:63.2,63.17 1 1
+github.com/observerly/iris/pkg/fits/fits.go:67.2,78.3 1 1
+github.com/observerly/iris/pkg/fits/fits.go:59.31,61.3 1 2
+github.com/observerly/iris/pkg/fits/fits.go:63.17,65.3 1 1
+github.com/observerly/iris/pkg/fits/fits.go:83.55,98.2 2 1
+github.com/observerly/iris/pkg/iris/monochrome.go:19.84,32.2 3 5
+github.com/observerly/iris/pkg/iris/monochrome.go:34.65,35.32 1 2
+github.com/observerly/iris/pkg/iris/monochrome.go:41.2,45.16 3 2
+github.com/observerly/iris/pkg/iris/monochrome.go:49.2,49.18 1 2
+github.com/observerly/iris/pkg/iris/monochrome.go:35.32,36.32 1 20
+github.com/observerly/iris/pkg/iris/monochrome.go:36.32,38.4 1 272
+github.com/observerly/iris/pkg/iris/monochrome.go:45.16,47.3 1 0
 github.com/observerly/iris/pkg/iris/rggb.go:22.85,34.2 2 10
 github.com/observerly/iris/pkg/iris/rggb.go:39.85,40.46 1 7
 github.com/observerly/iris/pkg/iris/rggb.go:41.14,42.19 1 3
@@ -63,11 +70,3 @@ github.com/observerly/iris/pkg/iris/convolution.go:106.2,111.13 5 128
 github.com/observerly/iris/pkg/iris/convolution.go:93.19,95.3 1 112
 github.com/observerly/iris/pkg/iris/convolution.go:97.19,99.3 1 112
 github.com/observerly/iris/pkg/iris/convolution.go:101.36,104.3 2 98
-github.com/observerly/iris/pkg/iris/monochrome.go:20.84,33.2 3 5
-github.com/observerly/iris/pkg/iris/monochrome.go:35.65,40.31 3 2
-github.com/observerly/iris/pkg/iris/monochrome.go:49.2,55.16 4 2
-github.com/observerly/iris/pkg/iris/monochrome.go:59.2,59.18 1 2
-github.com/observerly/iris/pkg/iris/monochrome.go:40.31,41.33 1 20
-github.com/observerly/iris/pkg/iris/monochrome.go:41.33,42.22 1 272
-github.com/observerly/iris/pkg/iris/monochrome.go:42.22,45.5 2 272
-github.com/observerly/iris/pkg/iris/monochrome.go:55.16,57.3 1 0

--- a/pkg/iris/monochrome.go
+++ b/pkg/iris/monochrome.go
@@ -5,7 +5,6 @@ import (
 	"image"
 	"image/color"
 	"image/jpeg"
-	"sync"
 )
 
 type MonochromeExposure struct {
@@ -33,20 +32,11 @@ func NewMonochromeExposure(exposure [][]uint32, xs int, ys int) MonochromeExposu
 }
 
 func (m *MonochromeExposure) Preprocess() (bytes.Buffer, error) {
-	var wg sync.WaitGroup
-
-	wg.Add(m.Width * m.Height)
-
-	for i := 0; i < m.Width; i++ {
-		for j := 0; j < m.Height; j++ {
-			go func(i, j int) {
-				m.Image.SetGray(i, j, color.Gray{uint8(m.Raw[i][j])})
-				wg.Done()
-			}(i, j)
+	for j := 0; j < m.Height; j++ {
+		for i := 0; i < m.Width; i++ {
+			m.Image.SetGray(i, j, color.Gray{uint8(m.Raw[j][i])})
 		}
 	}
-
-	wg.Wait()
 
 	var buff bytes.Buffer
 


### PR DESCRIPTION
fix: Removed sync.WaitGroup from (m *MonochromeExposure) Preprocess(). 

Includes reverse access of m.Raw to m.Raw[j][i].