### PR TITLE
fix: Ensure we provide the correct matrix position for the gray.SetGray() call.

### DIFF
--- a/coverage.txt
+++ b/coverage.txt
@@ -75,8 +75,8 @@ github.com/observerly/iris/pkg/iris/monochrome.go:114.74,125.51 6 3
 github.com/observerly/iris/pkg/iris/monochrome.go:135.2,135.47 1 3
 github.com/observerly/iris/pkg/iris/monochrome.go:139.2,141.29 2 3
 github.com/observerly/iris/pkg/iris/monochrome.go:125.51,128.30 2 3417824
-github.com/observerly/iris/pkg/iris/monochrome.go:128.30,130.4 1 437549
-github.com/observerly/iris/pkg/iris/monochrome.go:130.9,132.4 1 2980275
+github.com/observerly/iris/pkg/iris/monochrome.go:128.30,130.4 1 467899
+github.com/observerly/iris/pkg/iris/monochrome.go:130.9,132.4 1 2949925
 github.com/observerly/iris/pkg/iris/monochrome.go:135.47,137.3 1 3417824
 github.com/observerly/iris/pkg/iris/monochrome.go:144.73,154.51 5 1
 github.com/observerly/iris/pkg/iris/monochrome.go:164.2,164.47 1 1

--- a/pkg/iris/monochrome.go
+++ b/pkg/iris/monochrome.go
@@ -99,7 +99,7 @@ func (m *MonochromeExposure) Preprocess() (bytes.Buffer, error) {
 	gray := image.NewGray(bounds)
 
 	setPixel := func(gray *image.Gray, x int, y int) {
-		gray.SetGray(x, y, color.Gray{uint8(m.Raw[y][x])})
+		gray.SetGray(x, y, color.Gray{uint8(m.Raw[x][y])})
 	}
 
 	utils.DeferForEachPixel(size, func(x, y int) {
@@ -123,7 +123,7 @@ func (m *MonochromeExposure) ApplyNoiseReduction() (bytes.Buffer, error) {
 	m.Noise = noise.GetGaussianNoise()
 
 	setPixel := func(gray *image.Gray, x int, y int) {
-		pixel := m.Raw[y][x]
+		pixel := m.Raw[x][y]
 
 		if pixel < uint32(m.Noise) {
 			gray.SetGray(x, y, color.Gray{Y: 0})

--- a/pkg/iris/monochrome_test.go
+++ b/pkg/iris/monochrome_test.go
@@ -377,11 +377,11 @@ func TestNewNoiseExtractorGaussianNoisePngImage(t *testing.T) {
 
 	bounds := img.Bounds()
 
-	ex := make([][]uint32, bounds.Dy())
+	ex := make([][]uint32, bounds.Dx())
 
-	for y := 0; y < bounds.Dy(); y++ {
-		row := make([]uint32, bounds.Dx())
-		ex[y] = row
+	for x := 0; x < bounds.Dx(); x++ {
+		col := make([]uint32, bounds.Dy())
+		ex[x] = col
 	}
 
 	mono := NewMonochromeExposure(ex, bounds.Dx(), bounds.Dy())
@@ -390,7 +390,7 @@ func TestNewNoiseExtractorGaussianNoisePngImage(t *testing.T) {
 		for i := 0; i < bounds.Dx(); i++ {
 			r, g, b, _ := img.At(i, j).RGBA()
 			lum := 0.299*float64(r) + 0.587*float64(g) + 0.114*float64(b)
-			mono.Raw[j][i] = uint32(lum / 256)
+			mono.Raw[i][j] = uint32(lum / 256)
 		}
 	}
 
@@ -445,11 +445,11 @@ func TestNewNoiseExtractorGaussianNoise16PngImage(t *testing.T) {
 
 	bounds := img.Bounds()
 
-	ex := make([][]uint32, bounds.Dy())
+	ex := make([][]uint32, bounds.Dx())
 
-	for y := 0; y < bounds.Dy(); y++ {
-		row := make([]uint32, bounds.Dx())
-		ex[y] = row
+	for x := 0; x < bounds.Dx(); x++ {
+		col := make([]uint32, bounds.Dy())
+		ex[x] = col
 	}
 
 	mono := NewMonochromeExposure(ex, bounds.Dx(), bounds.Dy())
@@ -458,7 +458,7 @@ func TestNewNoiseExtractorGaussianNoise16PngImage(t *testing.T) {
 		for i := 0; i < bounds.Dx(); i++ {
 			r, g, b, _ := img.At(i, j).RGBA()
 			lum := 0.299*float64(r) + 0.587*float64(g) + 0.114*float64(b)
-			mono.Raw[j][i] = uint32(lum / 256)
+			mono.Raw[i][j] = uint32(lum / 256)
 		}
 	}
 


### PR DESCRIPTION
fix: Ensure we provide the correct matrix position for the gray.SetGray() call.