### PR TITLE
chore: Upgraded to go version 1.19.*.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: CI/CD Build
     strategy:
       matrix:
-        go: [ '1.17.x', '1.18.x' ]
+        go: [ '1.17.x', '1.18.x', '1.19.x' ]
         os: [ ubuntu-latest ]
 
     runs-on: ${{ matrix.os }}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/observerly/iris
 
-go 1.17
+go 1.19


### PR DESCRIPTION
chore: Upgraded to go version 1.19.*. 

Includes updated ci.yml .github/workflow to run against 1.19.x in the testing strategy matrix.