### PR TITLE
chore: Upgraded to go version 1.21.*.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: CI/CD Build
     strategy:
       matrix:
-        go: [ '1.17.x', '1.18.x', '1.19.x' ]
+        go: [ '1.17.x', '1.18.x', '1.19.x', '1.20.x', '1.21.x' ]
         os: [ ubuntu-latest ]
 
     runs-on: ${{ matrix.os }}
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Go Setup
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/observerly/iris
 
-go 1.19
+go 1.21
 
 require gonum.org/v1/gonum v0.14.0
 


### PR DESCRIPTION
chore: Upgraded to go version 1.21.*. 

Includes updated ci.yml .github/workflow to run against 1.21.x in the testing strategy matrix.