### PR TITLE
feat: add SortByTagInterface type to metadata module in @observerly/iris

### DIFF
--- a/pkg/ifd/entry.go
+++ b/pkg/ifd/entry.go
@@ -14,6 +14,11 @@ import "encoding/binary"
 
 /*****************************************************************************************************************/
 
+// Length of an IFD entry in bytes.
+const IFDLengthInBytes = 12
+
+/*****************************************************************************************************************/
+
 // An IFDEntry is a single entry in an Image File Directory.
 // A value of type DataTypeRational is composed of two 32-bit values,
 // thus data contains two uints (numerator and denominator) for a single number.
@@ -42,5 +47,17 @@ func (e IFDEntry) PutData(p []byte) {
 		}
 	}
 }
+
+/*****************************************************************************************************************/
+
+type SortByTagInterface []IFDEntry
+
+/*****************************************************************************************************************/
+
+func (s SortByTagInterface) Len() int { return len(s) }
+
+func (s SortByTagInterface) Less(i, j int) bool { return s[i].Tag < s[j].Tag }
+
+func (s SortByTagInterface) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
 /*****************************************************************************************************************/


### PR DESCRIPTION
feat: add SortByTagInterface type to metadata module in @observerly/iris